### PR TITLE
Implemented quick fixes for bugs in move*() functions

### DIFF
--- a/Arduino Library/Sparki.cpp
+++ b/Arduino Library/Sparki.cpp
@@ -315,13 +315,13 @@ void SparkiClass::RGB(uint8_t R, uint8_t G, uint8_t B)
 
 void SparkiClass::moveRight(float deg)
 {
-  float turn = 21.388888*deg;
+  float turn = 22.667184*deg;
   if(deg == 0){
       moveRight();
   }
   else{
       if(deg < 0){
-        moveLeft(deg);
+        moveLeft(-deg);
       }
       else{
           moveRight();
@@ -340,13 +340,13 @@ void SparkiClass::moveRight()
 
 void SparkiClass::moveLeft(float deg)
 {
-  float turn = 21.388888*deg;
+  float turn = 22.667184*deg;
   if(deg == 0){
       moveLeft();
   }
   else{
       if(deg < 0){
-        moveRight(deg);
+        moveRight(-deg);
       }
       else{
           moveLeft();
@@ -365,16 +365,16 @@ void SparkiClass::moveLeft()
 
 void SparkiClass::moveForward(float cm)
 {
-  float run = 222.222222*cm;
+  float run = 303.797428*cm;
   if(cm == 0){
-      moveBackward();
+      moveForward();
   }
   else{
       if(cm < 0){
-        moveForward(cm);
+        moveBackward(-cm);
       }
       else{
-          moveBackward();
+          moveForward();
           delay(long(run));
           moveStop();
       }
@@ -390,16 +390,16 @@ void SparkiClass::moveForward()
 
 void SparkiClass::moveBackward(float cm)
 {
-  float run = 222.222222*cm;
+  float run = 303.797428*cm;
   if(cm == 0){
-      moveForward();
+      moveBackward();
   }
   else{
       if(cm < 0){
-        moveBackward(cm);
+        moveForward(-cm);
       }
       else{
-          moveForward();
+          moveBackward();
           delay(long(run));
           moveStop();
       }

--- a/Arduino Library/Sparki.cpp
+++ b/Arduino Library/Sparki.cpp
@@ -14,19 +14,6 @@
 #include "SparkiEEPROM.h"
 #include "Sparkii2c.h"
 
-static int8_t step_dir[3];                 // -1 = ccw, 1 = cw  
-static volatile uint8_t speed_index[3];     // counter controlling motor speed 
-static uint8_t motor_speed[3];              // stores last set motor speed (0-100%)
-static volatile int8_t step_index[3];       // index into _steps array  
-static uint8_t _steps_right[9];                   // bytes defining stepper coil activations
-static uint8_t _steps_left[9];                   // bytes defining stepper coil activations
-static volatile uint32_t remainingSteps[3]; // number of steps before stopping motor
-static volatile uint32_t isRunning[3];      // tells if motor is running
-
-static volatile int speedCounter[3];      // variable used in maintaing speed
-static volatile int speedCount[3];      // what speedCount is set at when speed cycle resets
-
-static volatile uint8_t shift_outputs[3];      // tells if motor is running
 
 // initialize the RGB timer variables
 static volatile uint8_t RGB_vals[3];
@@ -56,7 +43,6 @@ volatile int8_t servo_deg_offset = 0;
 
 SparkiClass sparki;
 
-//static volatile int speedCounter;
 
 SparkiClass::SparkiClass()
 {
@@ -112,42 +98,36 @@ void SparkiClass::begin( ) {
   
   // Clear out the shift registers
   PORTD &= 0xDF;    // pull PD5 low
-  SPI.transfer(shift_outputs[1]);
-  SPI.transfer(shift_outputs[0]);
+  SPI.transfer(0x00);
+  SPI.transfer(0x00);
   PORTD |= 0x20;    // pull PD5 high to latch in spi transfers
 
 
   // Setup the IR Switch
   irSwitch = 0;
 
-  // defining steps for the stepper motors
-  _steps_left[0] = 0x10;
-  _steps_left[1] = 0x30;
-  _steps_left[2] = 0x20;
-  _steps_left[3] = 0x60;
-  _steps_left[4] = 0x40;
-  _steps_left[5] = 0xC0;
-  _steps_left[6] = 0x80;
-  _steps_left[7] = 0x90;
-  _steps_left[8]  = 0x00;
-
-  _steps_right[0] = 0x01;
-  _steps_right[1] = 0x03;
-  _steps_right[2] = 0x02;
-  _steps_right[3] = 0x06;
-  _steps_right[4] = 0x04;
-  _steps_right[5] = 0x0C;
-  _steps_right[6] = 0x08;
-  _steps_right[7] = 0x09;
-  _steps_right[8] = 0x00;
-
   beginDisplay();
   updateLCD();
 
-  // Setup initial Stepper settings
-  motor_speed[MOTOR_LEFT] = motor_speed[MOTOR_RIGHT] = motor_speed[MOTOR_GRIPPER] =100;
-  
-  
+  // BEGIN: Motor Setup
+
+  initMotorControlWord ( SPARKI_MOTOR_ID_MASK_ALL, 0x11 );
+  initMotorStatusWord  ( SPARKI_MOTOR_ID_MASK_ALL, 0x00 );
+
+  wheelDiameterUmEff   = SPARKI_WHEEL_DIAMETER_BASELINE_UM;
+  wheelSeparationUmEff = SPARKI_WHEEL_SEPARATION_BASELINE_UM;
+
+  driveMmToStepsEffFp = SPARKI_MOTOR_DRIVE_MM_TO_STEPS_FP;
+  spinDegToStepsEffFp = SPARKI_MOTOR_SPIN_DEG_TO_STEPS_FP;
+  turnRadMmAngleDegToStepsEffFp = SPARKI_TURN_RADIUSMM_ANGLEDEG_TO_STEPS_FP;
+
+  wheelSpeedPercentDefault   = SPARKI_MOTOR_SPEED_DEFAULT_PERCENT;
+  gripperSpeedPercentDefault = SPARKI_MOTOR_SPEED_DEFAULT_PERCENT;
+
+  distanceOfZeroMeansInfinity = true;
+  gripperSpacingMm = -1;
+
+  // END: Motor Setup
   
   // Set up the scheduler routine to run every 100uS, based off Timer4 interrupt
   cli();          // disable all interrupts
@@ -313,179 +293,1427 @@ void SparkiClass::RGB(uint8_t R, uint8_t G, uint8_t B)
 	RGB_vals[2] = B;
 }
 
-void SparkiClass::moveRight(float deg)
-{
-  float turn = 22.667184*deg;
-  if(deg == 0){
-      moveRight();
-  }
-  else{
-      if(deg < 0){
-        moveLeft(-deg);
-      }
-      else{
-          moveRight();
-          delay(long(turn));
-          moveStop();
-      }
-  }
+// ----------------------------------------------------------------------------
+// Motor Control: Setup and Support Functions
+// ----------------------------------------------------------------------------
+
+void SparkiClass::primeMotors () {
+
+  cli ();
+  setupMotorForSteps (
+    SPARKI_MOTOR_ID_MASK_WHEEL_LEFT,
+    SPARKI_MOTOR_PRIMING_STEPS,
+    SPARKI_MOTOR_DIR_COUNTERCLOCKWISE,
+    SPARKI_MOTOR_SPEED_DEFAULT_PERCENT,
+    true
+  );
+  setupMotorForSteps (
+    SPARKI_MOTOR_ID_MASK_WHEEL_RIGHT,
+    SPARKI_MOTOR_PRIMING_STEPS,
+    SPARKI_MOTOR_DIR_CLOCKWISE,
+    SPARKI_MOTOR_SPEED_DEFAULT_PERCENT,
+    true
+  );
+  setupMotorForSteps (
+    SPARKI_MOTOR_ID_MASK_GRIPPER,
+    SPARKI_MOTOR_PRIMING_STEPS,
+    SPARKI_MOTOR_DIR_COUNTERCLOCKWISE,
+    SPARKI_MOTOR_SPEED_DEFAULT_PERCENT,
+    true
+  );
+  sei ();
+
+  startMotorRotation ( SPARKI_MOTOR_ID_MASK_ALL, true );
+
 }
 
-void SparkiClass::moveRight()
-{
-  motorRotate(MOTOR_LEFT, DIR_CCW, 100);
-  motorRotate(MOTOR_RIGHT, DIR_CCW, 100);
-  
+// ----------------------------------------------------------------------------
+
+void SparkiClass::initMotorControlWord (
+  uint8_t motorIdMask,
+  byte    initValue
+) {
+
+  initMotorWord ( motorControlWord, motorIdMask, initValue );
+
 }
 
-void SparkiClass::moveLeft(float deg)
-{
-  float turn = 22.667184*deg;
-  if(deg == 0){
-      moveLeft();
-  }
-  else{
-      if(deg < 0){
-        moveRight(-deg);
-      }
-      else{
-          moveLeft();
-          delay(long(turn));
-          moveStop();
-      }
-  }
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::initMotorStatusWord (
+  uint8_t motorIdMask,
+  byte    initValue
+) {
+
+  initMotorWord ( motorStatusWord, motorIdMask, initValue );
+
 }
 
-void SparkiClass::moveLeft()
-{
-  motorRotate(MOTOR_LEFT, DIR_CW, 100);
-  motorRotate(MOTOR_RIGHT, DIR_CW, 100);
-  
-}
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-void SparkiClass::moveForward(float cm)
-{
-  float run = 303.797428*cm;
-  if(cm == 0){
-      moveForward();
-  }
-  else{
-      if(cm < 0){
-        moveBackward(-cm);
-      }
-      else{
-          moveForward();
-          delay(long(run));
-          moveStop();
-      }
-  }
-}
+void SparkiClass::initMotorWord (
+  volatile byte *  motorWord,
+           uint8_t motorIdMask,
+           byte    initValue
+) {
 
-void SparkiClass::moveForward()
-{
-  motorRotate(MOTOR_LEFT, DIR_CCW, 100);
-  motorRotate(MOTOR_RIGHT, DIR_CW, 100);
-  
-}
+  uint8_t motorIndex;
 
-void SparkiClass::moveBackward(float cm)
-{
-  float run = 303.797428*cm;
-  if(cm == 0){
-      moveBackward();
-  }
-  else{
-      if(cm < 0){
-        moveForward(-cm);
-      }
-      else{
-          moveBackward();
-          delay(long(run));
-          moveStop();
-      }
-  }
-}
+  motorIdMask &= SPARKI_MOTOR_ID_MASK_ALL;
 
-void SparkiClass::moveBackward()
-{
-  motorRotate(MOTOR_LEFT, DIR_CW, 100);
-  motorRotate(MOTOR_RIGHT, DIR_CCW, 100);
-}
-
-void SparkiClass::moveStop()
-{
-  motorStop(MOTOR_LEFT);
-  motorStop(MOTOR_RIGHT);
-}
-
-void SparkiClass::gripperOpen()
-{
-  motorRotate(MOTOR_GRIPPER, DIR_CCW, 100);
-}
-void SparkiClass::gripperClose()
-{
-  motorRotate(MOTOR_GRIPPER, DIR_CW, 100);
-}
-void SparkiClass::gripperStop()
-{
-  motorStop(MOTOR_GRIPPER);
-}
-
-void SparkiClass::motorRotate(int motor, int direction,  int speed)
-{
-   //Serial.print("Motor ");Serial.print(motor); Serial.print(" rotate, dir= "); Serial.println(direction);
-   uint8_t oldSREG = SREG;
-   cli();
-   motor_speed[motor] = speed;  
-   step_dir[motor] = direction;  
-   remainingSteps[motor] = ULONG_MAX; // motor stops after this many steps, almost 50 days of stepping if motor not stopped
-   isRunning[motor] = true;
-   speedCount[motor] = int(100.0/float(motor_speed[motor])*5.0);
-   speedCounter[motor] = speedCount[motor];
-   SREG = oldSREG; 
-   sei();
-   delay(10);
-}
-
-void SparkiClass::motorStop(int motor)
-{
-   //Serial.println("Motor Stop"); 
-   motor_speed[motor] = 0;  
-   setSteps(motor, 0);
-}
-
-void SparkiClass::motorsRotateSteps( int leftDir, int rightDir,  int speed, uint32_t steps, bool wait)
-{
-  uint8_t oldSREG = SREG;
-  cli();
-  motor_speed[MOTOR_LEFT] = motor_speed[MOTOR_RIGHT] = speed;  
-  step_dir[MOTOR_LEFT] = leftDir;   
-  step_dir[MOTOR_RIGHT] = rightDir; 
-  remainingSteps[MOTOR_LEFT] = remainingSteps[MOTOR_RIGHT] = steps;
-  isRunning[MOTOR_LEFT] = isRunning[MOTOR_RIGHT] = true;
-
-  SREG = oldSREG; 
-  sei();
-  if( wait)
-  {
-    while ( areMotorsRunning() ){
-      delay(10);  // remainingSteps is decrimented in the timer callback     
+  motorIndex = 0;
+  while ( motorIdMask != 0x00 ) {
+    if ( motorIdMask & 0x01 ) {
+      motorWord[motorIndex] = initValue;
     }
-  }  
- 
+    motorIdMask >>= 1;
+    motorIndex++;
+  }
+
+}
+
+// ----------------------------------------------------------------------------
+
+void SparkiClass::modifyMotorControlWordBit (
+  byte    motorIdMask,
+  byte    bitSelectMask,
+  boolean bitValue,
+  boolean motorIdIsIndex
+) {
+
+  modifyMotorWordBit ( motorControlWord, motorIdMask, bitSelectMask, bitValue, motorIdIsIndex );
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::modifyMotorStatusWordBit (
+  byte    motorIdMask,
+  byte    bitSelectMask,
+  boolean bitValue,
+  boolean motorIdIsIndex
+) {
+
+  modifyMotorWordBit ( motorStatusWord, motorIdMask, bitSelectMask, bitValue, motorIdIsIndex );
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::modifyMotorWordBit (
+  volatile byte *  motorWord,  // pointer to array of motor words
+           byte    motorIdMask,
+           byte    bitSelectMask,
+           boolean bitValue,
+           boolean motorIdIsIndex
+) {
+
+  motorIdMask &= SPARKI_MOTOR_ID_MASK_ALL;
+
+  if ( motorIdIsIndex ) {
+
+    if ( bitValue ) motorWord[motorIdMask] |=   bitSelectMask;
+    else            motorWord[motorIdMask] &= ~ bitSelectMask;
+
+  }  // if ( motorIdIsIndex )
+  else {
+
+    uint8_t motorIndex;
+
+    motorIndex = 0;
+    while ( motorIdMask != 0x00 ) {
+      if ( motorIdMask & 0x01 ) {
+        if ( bitValue ) motorWord[motorIndex] |=   bitSelectMask;
+        else            motorWord[motorIndex] &= ~ bitSelectMask;
+      }
+      motorIdMask >>= 1;
+      motorIndex++;
+    }
+
+  }  // if ( motorIdIsIndex ) ... else
+
+}
+
+// ----------------------------------------------------------------------------
+
+void SparkiClass::setWheelDiameter (
+  uint16_t wheelDiameterUm
+) {
+
+  wheelDiameterUmEff = wheelDiameterUm;
+
+  updateDriveMmToStepsFactor ();
+  updateSpinDegToStepsFactor ();
+
+  updateTurnRadMmAngleDegToStepsFactor ();
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::setWheelSeparation (
+  uint16_t wheelSeparationUm
+) {
+
+  wheelSeparationUmEff = wheelSeparationUm;
+
+  updateSpinDegToStepsFactor ();
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::updateDriveMmToStepsFactor () {
+
+  uint16_t wheelDiaRatioFp;
+
+  wheelDiaRatioFp = ( (uint32_t) SPARKI_WHEEL_DIAMETER_BASELINE_UM << 15 ) / wheelDiameterUmEff;
+
+  driveMmToStepsEffFp = ( (uint32_t) SPARKI_MOTOR_DRIVE_MM_TO_STEPS_FP * wheelDiaRatioFp + ( 1 << 14 ) ) >> 15;
+
+  // NOTE: Above fixed-pint precision of 15 bits assumes that wheel
+  // diameter does not exceed 10 bits; with actual Sparki wheel
+  // diameter around 51.0mm or 510 mm/10, this requirement is met.
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::updateSpinDegToStepsFactor () {
+
+  uint16_t wheelDiaRatioFp;
+  uint16_t wheelSepRatioFp;
+  uint16_t compoundRatioFp;
+
+  wheelDiaRatioFp = ( (uint32_t) SPARKI_WHEEL_DIAMETER_BASELINE_UM << 15 ) / wheelDiameterUmEff;
+  wheelSepRatioFp = ( (uint32_t) wheelSeparationUmEff << 15 ) / SPARKI_WHEEL_SEPARATION_BASELINE_UM;
+  compoundRatioFp = ( (uint32_t) wheelDiaRatioFp * wheelSepRatioFp ) >> 15;
+
+  spinDegToStepsEffFp = ( (uint32_t) SPARKI_MOTOR_SPIN_DEG_TO_STEPS_FP * compoundRatioFp + ( 1 << 14 ) ) >> 15;
+
+  // NOTE: Above fixed-pint precision of 15 bits assumes that wheel
+  // diameter and separation do not exceed 10 bits each; with
+  // Sparki wheel diameter around 51.0mm or 510 mm/10 and separation
+  // around 85.5 mm or 855 mm/10, this requirement is met.
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::updateTurnRadMmAngleDegToStepsFactor () {
+
+  uint16_t wheelDiaRatioFp;
+
+  wheelDiaRatioFp = ( (uint32_t) SPARKI_WHEEL_DIAMETER_BASELINE_UM << 15 ) / wheelDiameterUmEff;
+
+  turnRadMmAngleDegToStepsEffFp = ( (uint32_t) SPARKI_TURN_RADIUSMM_ANGLEDEG_TO_STEPS_FP * wheelDiaRatioFp + ( 1 << 14 ) ) >> 15;
+
+}
+
+// ----------------------------------------------------------------------------
+
+void SparkiClass::enableActiveHoldForWheels (
+  boolean enableActiveHold
+) {
+
+  enableActiveMotorHold ( SPARKI_MOTOR_ID_MASK_WHEELS, enableActiveHold );
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::enableActiveHoldForGripper (
+  boolean enableActiveHold
+) {
+
+  enableActiveMotorHold ( SPARKI_MOTOR_ID_MASK_GRIPPER, enableActiveHold );
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+boolean SparkiClass::activeHoldIsEnabledForWheels () {
+
+  return activeMotorHoldIsEnabledForAny ( SPARKI_MOTOR_ID_MASK_WHEELS );
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+boolean SparkiClass::activeHoldIsEnabledForGripper () {
+
+  return activeMotorHoldIsEnabledForAny ( SPARKI_MOTOR_ID_MASK_GRIPPER );
+
+}
+
+// ----------------------------------------------------------------------------
+
+void SparkiClass::enableActiveMotorHold (
+  byte    motorIdMask, 
+  boolean enableActiveHold
+) {
+
+  modifyMotorStatusWordBit ( motorIdMask, SPARKI_MOTOR_STATUS_MASK_ACT_HOLD_IS_ON, enableActiveHold );
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+boolean SparkiClass::activeMotorHoldIsEnabledForAny (
+  byte motorIdMask
+) {
+
+  boolean activeHoldIsOn;
+  uint8_t motorIndex;
+
+  motorIdMask &= SPARKI_MOTOR_ID_MASK_ALL;
+
+  activeHoldIsOn = false;
+
+  motorIndex = 0;
+  while ( motorIdMask != 0x00 ) {
+    if ( motorIdMask & 0x01 ) {
+       activeHoldIsOn = activeHoldIsOn || ( motorStatusWord[motorIndex] & SPARKI_MOTOR_STATUS_MASK_ACT_HOLD_IS_ON );
+    }
+    motorIdMask >>= 1;
+    motorIndex++;
+  }
+
+  return activeHoldIsOn;
+
+}
+
+// ----------------------------------------------------------------------------
+
+void SparkiClass::enableBacklashCompForWheels (
+  boolean enableBacklashComp
+) {
+
+  enableMotorBacklashComp ( SPARKI_MOTOR_ID_MASK_WHEELS, enableBacklashComp );
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::enableBacklashCompForGripper (
+  boolean enableBacklashComp
+) {
+
+  enableMotorBacklashComp ( SPARKI_MOTOR_ID_MASK_GRIPPER, enableBacklashComp );
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+boolean SparkiClass::backlashCompIsEnabledForWheels () {
+
+  return motorBacklashCompIsEnabledForAny ( SPARKI_MOTOR_ID_MASK_WHEELS );
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+boolean SparkiClass::backlashCompIsEnabledForGripper () {
+
+  return motorBacklashCompIsEnabledForAny ( SPARKI_MOTOR_ID_MASK_GRIPPER );
+
+}
+
+// ----------------------------------------------------------------------------
+
+void SparkiClass::enableMotorBacklashComp (
+  byte    motorIdMask, 
+  boolean enableBacklashComp
+) {
+
+  if ( enableBacklashComp ) {
+    modifyMotorStatusWordBit ( motorIdMask, SPARKI_MOTOR_STATUS_MASK_BLCOMP_IS_ON, true );
+  }
+  else {
+    modifyMotorStatusWordBit (
+      motorIdMask,
+      SPARKI_MOTOR_STATUS_MASK_BLCOMP_IS_ON | SPARKI_MOTOR_STATUS_MASK_BLCOMP_IS_PEND, 
+      false
+    );
+  }
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+boolean SparkiClass::motorBacklashCompIsEnabledForAny (
+  byte motorIdMask
+) {
+
+  boolean backlashCompIsOn;
+  uint8_t motorIndex;
+
+  motorIdMask &= SPARKI_MOTOR_ID_MASK_ALL;
+
+  backlashCompIsOn = false;
+
+  motorIndex = 0;
+  while ( motorIdMask != 0x00 ) {
+    if ( motorIdMask & 0x01 ) {
+       backlashCompIsOn = backlashCompIsOn || ( motorStatusWord[motorIndex] & SPARKI_MOTOR_STATUS_MASK_BLCOMP_IS_ON );
+    }
+    motorIdMask >>= 1;
+    motorIndex++;
+  }
+  
+  return backlashCompIsOn;
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::performMotorBacklashCompensation (
+  byte motorIdMask
+) {
+
+  uint8_t  motorIndex;
+  byte     motorIdMaskForBlComp;
+  uint32_t savedStepCount[SPARKI_MOTOR_COUNT];
+
+  motorIdMask &= SPARKI_MOTOR_ID_MASK_ALL;
+  motorIdMaskForBlComp = motorIdMask;
+
+  motorIndex = 0;
+  while ( motorIdMask != 0x00 ) {
+    if ( motorIdMask & 0x01 ) {
+      if ( motorStatusWord[motorIndex] & SPARKI_MOTOR_STATUS_MASK_BLCOMP_IS_PEND ) {
+        savedStepCount[motorIndex] = motorRemainingSteps[motorIndex];
+        motorRemainingSteps[motorIndex] = SPARKI_MOTOR_STEPS_OF_BACKLASH;
+      }
+      else {
+        motorIdMaskForBlComp &= ~ ( 0x01 << motorIndex );
+      }
+    }
+    motorIdMask >>= 1;
+    motorIndex++;
+  }
+
+  if ( motorIdMaskForBlComp != 0x00 ) {
+
+    cli ();
+    modifyMotorStatusWordBit ( motorIdMaskForBlComp, SPARKI_MOTOR_STATUS_MASK_MTR_IS_RUNNING, true );
+    sei ();
+    while ( anyMotorIsRunning(motorIdMaskForBlComp) ) delay ( 10 );
+
+    motorIndex = 0;
+    while ( motorIdMaskForBlComp != 0x00 ) {
+      if ( motorIdMaskForBlComp & 0x01 ) {
+        modifyMotorStatusWordBit ( motorIndex, SPARKI_MOTOR_STATUS_MASK_BLCOMP_IS_PEND, false, true );
+        motorRemainingSteps[motorIndex] = savedStepCount[motorIndex];
+      }
+      motorIdMaskForBlComp >>= 1;
+      motorIndex++;
+    }
+
+  }  // if ( motorIdMaskForBlComp != 0x00 )
+
+}
+
+// ----------------------------------------------------------------------------
+
+uint8_t SparkiClass::motorSpeedPercentToIntEvents (
+  uint8_t speedPercent
+) {
+
+  uint8_t  slowdownPercent;
+  uint32_t updatePeriodExtraUs;
+  uint32_t updatePeriodTotalUs;
+  uint16_t updatePeriodIntEvents;
+  uint8_t  updateIntervalIntEvents;
+
+
+  if ( speedPercent > 100 ) speedPercent = 100;
+  slowdownPercent = 100 - speedPercent;
+  updatePeriodExtraUs = (uint32_t) slowdownPercent * (
+                          SPARKI_MOTOR_UPDATE_PERIOD_MAX_US -
+                          SPARKI_MOTOR_UPDATE_PERIOD_MIN_US
+                        ) / 100;
+  updatePeriodTotalUs = SPARKI_MOTOR_UPDATE_PERIOD_MIN_US + updatePeriodExtraUs;
+  updatePeriodIntEvents = ( ( updatePeriodTotalUs << 1 ) / SPARKI_INTERRUPT_PERIOD_US + 1 ) >> 1;
+  updateIntervalIntEvents = updatePeriodIntEvents == 0 ? 0 : updatePeriodIntEvents - 1;
+
+  return updateIntervalIntEvents;
+
+  // NOTE: Bit shifts and +1 in updatePeriodIntEvents expression are to
+  // achieve rounding to the nearest half.
+
+  // FIXME (?): Not sure how smart the compiler is... If all the explicit
+  // intermediate variables result in lots of unique register allocations
+  // then consider trading off human readability for code efficiency and
+  // potentially mash everything into one giant expression.
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+uint8_t SparkiClass::motorIntEventsToSpeedPercent (
+  uint16_t updateIntervalIntEvents
+) {
+
+  uint16_t updatePeriodIntEvents;
+  uint32_t updatePeriodUs;
+  uint32_t updatePeriodExtraUs;
+  uint32_t updatePeriodExtraUsFp;
+  uint16_t slowdownPercentFp;
+  uint8_t  speedPercent;
+
+  updatePeriodIntEvents = updateIntervalIntEvents + 1;
+  updatePeriodUs = updatePeriodIntEvents * SPARKI_INTERRUPT_PERIOD_US;
+  updatePeriodExtraUs = updatePeriodUs - SPARKI_MOTOR_UPDATE_PERIOD_MIN_US;
+  updatePeriodExtraUsFp = updatePeriodExtraUs << 7;
+  slowdownPercentFp = updatePeriodExtraUsFp * 100 / (
+                        SPARKI_MOTOR_UPDATE_PERIOD_MAX_US -
+                        SPARKI_MOTOR_UPDATE_PERIOD_MIN_US
+                      );
+  speedPercent = 100 - ( slowdownPercentFp >> 7 );
+
+  return speedPercent;
+
+  // FIXME (?): Not sure how smart the compiler is... If all the explicit
+  // intermediate variables result in lots of unique register allocations
+  // then consider trading off human readability for code efficiency and
+  // potentially mash everything into one giant expression.
+
+}
+
+// ----------------------------------------------------------------------------
+// Motor Control: Primary Control Functions
+// ----------------------------------------------------------------------------
+
+uint32_t SparkiClass::driveDistanceToMotorSteps (
+  uint16_t distanceToDriveMm
+) {
+
+  uint32_t distanceToDriveSteps;
+
+  if ( distanceToDriveMm == 0 && distanceOfZeroMeansInfinity ) {
+    distanceToDriveSteps = 0;
+    distanceToDriveSteps = ~ distanceToDriveSteps;
+  }
+  else {
+
+    distanceToDriveSteps = (
+        (uint32_t) distanceToDriveMm * 
+    //  SPARKI_MOTOR_DRIVE_MM_TO_STEPS_FP
+        driveMmToStepsEffFp
+      ) >> SPARKI_MOTOR_DRIVE_MM_TO_STEPS_FP_FRACT_BITS;
+  // steps = mm * rev/mm * steps/rev
+  //       = mm * rev/mm / rev/steps
+  //       = mm * SPARKI_MOTOR_DRIVE_MM_TO_STEPS
+
+  }
+
+  return distanceToDriveSteps;
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+uint32_t SparkiClass::spinAngleToMotorSteps (
+  uint16_t angleToSpinDeg
+) {
+
+  uint32_t distanceToSpinSteps;
+
+  if ( angleToSpinDeg == 0 && distanceOfZeroMeansInfinity ) {
+    distanceToSpinSteps = 0;
+    distanceToSpinSteps = ~ distanceToSpinSteps;
+  }
+  else {
+
+    distanceToSpinSteps = (
+        (uint32_t) angleToSpinDeg *
+    //  SPARKI_MOTOR_SPIN_DEG_TO_STEPS_FP
+        spinDegToStepsEffFp 
+      ) >> SPARKI_MOTOR_SPIN_DEG_TO_STEPS_FP_FRACT_BITS;
+    // steps = deg * spin/deg * mm/spin * rev/mm * steps/rev
+    //       = deg / deg/spin * mm/spin / mm/rev * steps/rev
+    //       = ( deg * mm/spin * steps/rev ) / ( deg/spin * mm/rev )
+    //       = deg * SPARKI_MOTOR_SPIN_DEG_TO_STEPS
+
+  }
+
+  return distanceToSpinSteps;
+
+}
+
+// ----------------------------------------------------------------------------
+
+void SparkiClass::setupMotorForSteps (
+  byte     motorIdMask,
+  uint32_t stepCount,
+  boolean  stepClockwise,
+  uint8_t  speedPercent,
+  boolean  stopIfRunning
+) {
+
+  // NOTE: Typically, the caller of this function should disable
+  // interrupts before calling this function and enable interrupts
+  // again after this function's completion.
+
+  uint8_t motorIndex;
+  boolean motorIsRunningNow;
+  boolean priorDirWasCw;
+  boolean blCompWasPending;
+  boolean directionIsChanging;
+  boolean applyBacklashComp;
+
+  motorIdMask &= SPARKI_MOTOR_ID_MASK_ALL;
+
+  motorIndex = 0;
+  while ( motorIdMask != 0x00 ) {
+
+    if ( motorIdMask & 0x01 ) {
+
+      motorIsRunningNow = motorStatusWord[motorIndex] & SPARKI_MOTOR_STATUS_MASK_MTR_IS_RUNNING;
+      if ( motorIsRunningNow && stopIfRunning ) {
+        modifyMotorStatusWordBit ( motorIndex, SPARKI_MOTOR_STATUS_MASK_MTR_IS_RUNNING, false, true );
+        motorIsRunningNow = false;
+      }
+
+      if ( motorStatusWord[motorIndex] & SPARKI_MOTOR_STATUS_MASK_BLCOMP_IS_ON ) {
+        priorDirWasCw = motorStatusWord[motorIndex] & SPARKI_MOTOR_STATUS_MASK_DIR_IS_CW;
+        blCompWasPending = motorStatusWord[motorIndex] & SPARKI_MOTOR_STATUS_MASK_BLCOMP_IS_PEND;
+        directionIsChanging =   priorDirWasCw && ! stepClockwise ||
+                              ! priorDirWasCw &&   stepClockwise;
+        applyBacklashComp = ! blCompWasPending &&   directionIsChanging ||
+                              blCompWasPending && ! directionIsChanging;
+      } else {
+        applyBacklashComp = false;
+      }
+
+      modifyMotorStatusWordBit ( motorIndex, SPARKI_MOTOR_STATUS_MASK_DIR_IS_CW, stepClockwise, true );
+
+      motorUpdateIntervalIntEvents[motorIndex] = motorSpeedPercentToIntEvents ( speedPercent );
+
+      if ( ! motorIsRunningNow ||
+           motorTimeToUpdateIntEvents[motorIndex] > motorUpdateIntervalIntEvents[motorIndex] ) {
+        motorTimeToUpdateIntEvents[motorIndex] = motorUpdateIntervalIntEvents[motorIndex];
+      }
+
+      motorRemainingSteps[motorIndex] = stepCount;
+
+      if ( motorIsRunningNow ) {
+        if ( applyBacklashComp ) motorRemainingSteps[motorIndex] += SPARKI_MOTOR_STEPS_OF_BACKLASH;
+      } else {
+        modifyMotorStatusWordBit ( motorIndex, SPARKI_MOTOR_STATUS_MASK_BLCOMP_IS_PEND, applyBacklashComp, true );
+      }
+
+      // NOTE/FIXME: Applying backlash compensation to the wheels while
+      // they are running may not yield nice results with the current
+      // implementation. Improve this?
+
+    }  // if ( motorIdMask & 0x01 )
+
+    motorIdMask >>= 1;
+    motorIndex++;
+
+  }  // while ( motorIdMask != 0x00 )
+
+}
+
+// ----------------------------------------------------------------------------
+
+void SparkiClass::startMotorRotation (
+  byte    motorIdMask,
+  boolean waitUntilDone
+) {
+
+  byte    motorIdMaskSaved;
+  uint8_t motorIndex;
+
+  motorIdMask &= SPARKI_MOTOR_ID_MASK_ALL;
+
+  performMotorBacklashCompensation ( motorIdMask );
+
+//cli ();
+//modifyMotorStatusWordBit ( motorIdMask, SPARKI_MOTOR_STATUS_MASK_MTR_IS_RUNNING, true );
+//sei ();
+
+  motorIdMaskSaved = motorIdMask;
+  motorIndex = 0;
+  cli ();
+  while ( motorIdMask != 0x00 ) {
+    if ( motorIdMask & 0x01 ) {
+      if ( motorRemainingSteps[motorIndex] > 0 ) {
+        modifyMotorStatusWordBit ( motorIndex, SPARKI_MOTOR_STATUS_MASK_MTR_IS_RUNNING, true, true );
+      }
+    }
+    motorIdMask >>= 1;
+    motorIndex++;
+  }
+  sei ();
+  motorIdMask = motorIdMaskSaved;
+
+  if ( waitUntilDone ) while ( anyMotorIsRunning(motorIdMask) ) delay ( 10 );
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::stopMotorRotation (
+  byte motorIdMask
+) {
+
+  modifyMotorStatusWordBit ( motorIdMask, SPARKI_MOTOR_STATUS_MASK_MTR_IS_RUNNING, false );
+
+}
+
+// ----------------------------------------------------------------------------
+
+void SparkiClass::rotateMotorsBySteps (
+  byte     motorIdMask,
+  uint32_t stepCount,
+  int8_t   turnDirection,
+  boolean  waitUntilDone,
+  uint8_t  speedPercent
+) {
+
+  cli ();
+  setupMotorForSteps ( motorIdMask, stepCount, turnDirection, speedPercent, true );
+  sei ();
+
+  startMotorRotation ( motorIdMask, waitUntilDone );
+
+}
+
+// ----------------------------------------------------------------------------
+
+uint8_t SparkiClass::countOfMotorsRunning (
+  byte motorIdMask
+) {
+
+  boolean motorCount;
+  uint8_t motorIndex;
+
+  motorIdMask &= SPARKI_MOTOR_ID_MASK_ALL;
+
+  motorCount = 0;
+  motorIndex = 0;
+  cli ();
+  while ( motorIdMask != 0x00 ) {
+    if ( motorIdMask & 0x01 ) {
+      if ( motorStatusWord[motorIndex] & SPARKI_MOTOR_STATUS_MASK_MTR_IS_RUNNING ) motorCount++;
+    }
+    motorIdMask >>= 1;
+    motorIndex++;
+  }
+  sei ();
+  
+  return motorCount;
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+boolean SparkiClass::anyMotorIsRunning (
+  byte motorIdMask
+) {
+
+  boolean motorRunning;
+  uint8_t motorIndex;
+
+  motorIdMask &= SPARKI_MOTOR_ID_MASK_ALL;
+
+  motorRunning = false;
+  motorIndex = 0;
+  cli ();
+  while ( motorIdMask != 0x00 ) {
+    if ( motorIdMask & 0x01 ) {
+      motorRunning = motorRunning || ( motorStatusWord[motorIndex] & SPARKI_MOTOR_STATUS_MASK_MTR_IS_RUNNING );
+    }
+    motorIdMask >>= 1;
+    motorIndex++;
+  }
+  sei ();
+  
+  return motorRunning;
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+boolean SparkiClass::allMotorsAreRunning (
+  byte motorIdMask
+) {
+
+  boolean motorRunning;
+  uint8_t motorIndex;
+
+  motorIdMask &= SPARKI_MOTOR_ID_MASK_ALL;
+
+  motorRunning = true;
+  motorIndex = 0;
+  cli ();
+  while ( motorIdMask != 0x00 ) {
+    if ( motorIdMask & 0x01 ) {
+      motorRunning = motorRunning && ( motorStatusWord[motorIndex] & SPARKI_MOTOR_STATUS_MASK_MTR_IS_RUNNING );
+    }
+    motorIdMask >>= 1;
+    motorIndex++;
+  }
+  sei ();
+  
+  return motorRunning;
+
+}
+
+// ----------------------------------------------------------------------------
+
+void SparkiClass::drive (
+  int16_t  distanceToDriveMm,
+  boolean  directionIsFoward,
+  boolean  waitUntilDone,
+  int8_t   speedPercent
+) {
+
+  uint32_t distanceToDriveSteps;
+
+  if ( distanceToDriveMm < 0 ) {
+    directionIsFoward = ! directionIsFoward;
+    distanceToDriveMm = - distanceToDriveMm;
+  }
+
+  if ( speedPercent < 0 ) speedPercent = wheelSpeedPercentDefault;
+
+  waitUntilDone = waitUntilDone && distanceToDriveMm > 0;
+
+  distanceToDriveSteps = driveDistanceToMotorSteps ( distanceToDriveMm );
+
+  if ( distanceToDriveSteps > 0 ) {
+
+    cli ();
+
+    setupMotorForSteps (
+      SPARKI_MOTOR_ID_MASK_WHEEL_LEFT,
+      distanceToDriveSteps,
+      directionIsFoward ? SPARKI_MOTOR_DIR_COUNTERCLOCKWISE : SPARKI_MOTOR_DIR_CLOCKWISE,
+      speedPercent,
+      true
+    );
+
+    setupMotorForSteps (
+      SPARKI_MOTOR_ID_MASK_WHEEL_RIGHT,
+      distanceToDriveSteps,
+      directionIsFoward ? SPARKI_MOTOR_DIR_CLOCKWISE : SPARKI_MOTOR_DIR_COUNTERCLOCKWISE,
+      speedPercent,
+      true
+    );
+
+    sei ();
+
+    startMotorRotation ( SPARKI_MOTOR_ID_MASK_WHEELS, waitUntilDone );
+
+  }  // if ( distanceToDriveSteps > 0 )
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::driveForward (
+  int16_t  distanceToDriveMm,
+  boolean  waitUntilDone,
+  int8_t   speedPercent
+) {
+
+  drive ( distanceToDriveMm, true, waitUntilDone, speedPercent );
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::driveBackward (
+  int16_t  distanceToDriveMm,
+  boolean  waitUntilDone,
+  int8_t   speedPercent
+) {
+
+  drive ( distanceToDriveMm, false, waitUntilDone, speedPercent );
+
+}
+
+// ----------------------------------------------------------------------------
+
+void SparkiClass::spin (
+  int16_t angleToSpinDeg,
+  boolean directionIsRight,
+  boolean waitUntilDone,
+  int8_t  speedPercent
+) {
+
+  uint32_t distanceToSpinSteps;
+
+  if ( angleToSpinDeg < 0 ) {
+    directionIsRight = ! directionIsRight;
+    angleToSpinDeg = - angleToSpinDeg;
+  }
+
+  if ( speedPercent < 0 ) speedPercent = wheelSpeedPercentDefault;
+
+  waitUntilDone = waitUntilDone && angleToSpinDeg > 0;
+
+  distanceToSpinSteps = spinAngleToMotorSteps ( angleToSpinDeg );
+
+  if ( distanceToSpinSteps > 0 ) {
+
+    cli ();
+
+    setupMotorForSteps (
+      SPARKI_MOTOR_ID_MASK_WHEEL_LEFT,
+      distanceToSpinSteps,
+      directionIsRight ? SPARKI_MOTOR_DIR_COUNTERCLOCKWISE : SPARKI_MOTOR_DIR_CLOCKWISE,
+      speedPercent,
+      true
+    );
+
+    setupMotorForSteps (
+      SPARKI_MOTOR_ID_MASK_WHEEL_RIGHT,
+      distanceToSpinSteps,
+      directionIsRight ? SPARKI_MOTOR_DIR_COUNTERCLOCKWISE : SPARKI_MOTOR_DIR_CLOCKWISE,
+      speedPercent,
+      true
+    );
+
+    sei ();
+
+    startMotorRotation ( SPARKI_MOTOR_ID_MASK_WHEELS, waitUntilDone );
+
+  }  // if ( distanceToSpinSteps > 0 )
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::spinLeft (
+  int16_t angleToSpinDeg,
+  boolean waitUntilDone,
+  int8_t  speedPercent
+) {
+
+  spin ( angleToSpinDeg, SPARKI_MOTOR_DIR_COUNTERCLOCKWISE, waitUntilDone, speedPercent );
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::spinRight (
+  int16_t angleToSpinDeg,
+  boolean waitUntilDone,
+  int8_t  speedPercent
+) {
+
+  spin ( angleToSpinDeg, SPARKI_MOTOR_DIR_CLOCKWISE, waitUntilDone, speedPercent );
+
+}
+
+// ----------------------------------------------------------------------------
+
+void SparkiClass::turn (
+  int16_t angleToTurnDeg,
+  boolean directionIsRight,
+  int16_t radiusOfTurnMm,
+  boolean waitUntilDone,
+  int8_t  speedPercent
+) {
+
+  const uint8_t updatePeriodFractBits = 2;
+
+  int8_t   negRadSpinAngleDeg;
+  int8_t   halfWheelSeparationMm;
+  int16_t  outerWheelTurnRadiusMm;
+  int16_t  innerWheelTurnRadiusMm;
+  int32_t  turnRadiusMmToStepsEffFp;
+  int32_t  innerWheelDriveDistanceSteps;
+  int32_t  outerWheelDriveDistanceSteps;
+  int32_t  centerMoveDistanceSteps;
+  boolean  outerWheelDirIsForward;
+  boolean  innerWheelDirIsForward;
+  uint16_t minUpdatePeriodIntEvents;
+  uint16_t centerUpdatePeriodIntEv;
+  uint16_t outerWheelUpdatePeriodIntEv;
+  uint16_t innerWheelUpdatePeriodIntEv;
+  byte     outerWheelIdMask;
+  uint8_t  outerWheelIndex;
+  byte     innerWheelIdMask;
+  uint8_t  innerWheelIndex;
+  boolean  outerWheelDirIsClockwise;
+  boolean  innerWheelDirIsClockwise;
+
+  // Handle corner cases...
+
+  if ( speedPercent < 0 ) speedPercent = wheelSpeedPercentDefault;
+
+  if ( radiusOfTurnMm == 0 ) {
+    if ( angleToTurnDeg != 0 ) spin ( angleToTurnDeg, true, waitUntilDone, speedPercent );
+    return;
+  }
+
+  // Set up special handling of negative turn radius...
+
+  if ( ! SPARKI_WHEEL_TURN_WITH_NEG_RAD_ALTERNATE || radiusOfTurnMm >= 0 ) {
+    negRadSpinAngleDeg = 0;
+  }
+  else {
+    if ( directionIsRight && angleToTurnDeg < 0 || ! directionIsRight && angleToTurnDeg > 0 ) {
+      negRadSpinAngleDeg = -90;
+    }
+    else {
+      negRadSpinAngleDeg = +90;
+    }
+    radiusOfTurnMm   = - radiusOfTurnMm;
+    directionIsRight = ! directionIsRight;  
+    waitUntilDone    = true;
+  }
+
+  if ( negRadSpinAngleDeg != 0 ) spin ( + negRadSpinAngleDeg );
+
+  // Calculate turn radii for individual wheels...
+
+  halfWheelSeparationMm = wheelSeparationUmEff / 20;
+
+  outerWheelTurnRadiusMm = radiusOfTurnMm + halfWheelSeparationMm;
+  innerWheelTurnRadiusMm = radiusOfTurnMm - halfWheelSeparationMm;
+
+  // Calculate driving distance for center point (pen hole)
+  // and for each wheel...
+
+  turnRadiusMmToStepsEffFp = (int32_t) angleToTurnDeg * turnRadMmAngleDegToStepsEffFp;
+
+  centerMoveDistanceSteps = (
+    (int32_t) radiusOfTurnMm * turnRadiusMmToStepsEffFp
+  ) >> SPARKI_TURN_RADIUSMM_ANGLEDEG_TO_STEPS_FP_FRACT_BITS;
+
+  outerWheelDriveDistanceSteps = (
+    (int32_t) outerWheelTurnRadiusMm * turnRadiusMmToStepsEffFp
+  ) >> SPARKI_TURN_RADIUSMM_ANGLEDEG_TO_STEPS_FP_FRACT_BITS;
+
+  innerWheelDriveDistanceSteps = (
+    (int32_t) innerWheelTurnRadiusMm * turnRadiusMmToStepsEffFp
+  ) >> SPARKI_TURN_RADIUSMM_ANGLEDEG_TO_STEPS_FP_FRACT_BITS;
+
+  // Normalize driving distances to positive quantities...
+
+  centerMoveDistanceSteps = centerMoveDistanceSteps < 0 ? - centerMoveDistanceSteps : centerMoveDistanceSteps;
+
+  if ( outerWheelDriveDistanceSteps >= 0 ) {
+    outerWheelDirIsForward = true;
+  }
+  else {
+    outerWheelDirIsForward = false;
+    outerWheelDriveDistanceSteps = - outerWheelDriveDistanceSteps;
+  }
+
+  if ( innerWheelDriveDistanceSteps >= 0 ) {
+    innerWheelDirIsForward = true;
+  }
+  else {
+    innerWheelDirIsForward = false;
+    innerWheelDriveDistanceSteps = - innerWheelDriveDistanceSteps;
+  }
+
+  // Compute speed setting for each wheel...
+
+  minUpdatePeriodIntEvents = ( motorSpeedPercentToIntEvents (          100 ) + 1 ) << updatePeriodFractBits;
+  centerUpdatePeriodIntEv  = ( motorSpeedPercentToIntEvents ( speedPercent ) + 1 ) << updatePeriodFractBits;
+
+  outerWheelUpdatePeriodIntEv = centerMoveDistanceSteps * centerUpdatePeriodIntEv / outerWheelDriveDistanceSteps;
+  innerWheelUpdatePeriodIntEv = centerMoveDistanceSteps * centerUpdatePeriodIntEv / innerWheelDriveDistanceSteps;
+
+  if ( outerWheelUpdatePeriodIntEv < minUpdatePeriodIntEvents || innerWheelUpdatePeriodIntEv < minUpdatePeriodIntEvents ) {
+    if ( outerWheelUpdatePeriodIntEv <= innerWheelUpdatePeriodIntEv ) {
+      innerWheelUpdatePeriodIntEv = innerWheelUpdatePeriodIntEv * minUpdatePeriodIntEvents / outerWheelUpdatePeriodIntEv;
+      outerWheelUpdatePeriodIntEv = minUpdatePeriodIntEvents;
+    }
+    else {
+      outerWheelUpdatePeriodIntEv = outerWheelUpdatePeriodIntEv * minUpdatePeriodIntEvents / innerWheelUpdatePeriodIntEv;
+      innerWheelUpdatePeriodIntEv = minUpdatePeriodIntEvents;
+    }
+  }
+
+  outerWheelUpdatePeriodIntEv = ( outerWheelUpdatePeriodIntEv + ( 1 << updatePeriodFractBits-1 ) ) >> updatePeriodFractBits;
+  innerWheelUpdatePeriodIntEv = ( innerWheelUpdatePeriodIntEv + ( 1 << updatePeriodFractBits-1 ) ) >> updatePeriodFractBits;
+
+  // Drive the turn...
+
+  if ( directionIsRight ) {
+    outerWheelIdMask = SPARKI_MOTOR_ID_MASK_WHEEL_LEFT;
+    outerWheelIndex  = SPARKI_MOTOR_INDEX_WHEEL_LEFT;
+    outerWheelDirIsClockwise = ! outerWheelDirIsForward;
+    innerWheelIdMask = SPARKI_MOTOR_ID_MASK_WHEEL_RIGHT;
+    innerWheelIndex  = SPARKI_MOTOR_INDEX_WHEEL_RIGHT;
+    innerWheelDirIsClockwise =   innerWheelDirIsForward;
+  }
+  else {
+    outerWheelIdMask = SPARKI_MOTOR_ID_MASK_WHEEL_RIGHT;
+    outerWheelIndex  = SPARKI_MOTOR_INDEX_WHEEL_RIGHT;
+    outerWheelDirIsClockwise =   outerWheelDirIsForward;
+    innerWheelIdMask = SPARKI_MOTOR_ID_MASK_WHEEL_LEFT;
+    innerWheelIndex  = SPARKI_MOTOR_INDEX_WHEEL_LEFT;
+    innerWheelDirIsClockwise = ! innerWheelDirIsForward;
+  }
+
+  cli ();
+
+  setupMotorForSteps (
+    outerWheelIdMask,
+    outerWheelDriveDistanceSteps,
+    outerWheelDirIsClockwise ? SPARKI_MOTOR_DIR_CLOCKWISE : SPARKI_MOTOR_DIR_COUNTERCLOCKWISE,
+    0,  // speed percent is don't-care; interrupt interval is set directly below
+    true
+  );
+  motorUpdateIntervalIntEvents[outerWheelIndex] = outerWheelUpdatePeriodIntEv - 1;
+  motorTimeToUpdateIntEvents[outerWheelIndex]   = outerWheelUpdatePeriodIntEv - 1;
+
+  setupMotorForSteps (
+    innerWheelIdMask,
+    innerWheelDriveDistanceSteps,
+    innerWheelDirIsClockwise ? SPARKI_MOTOR_DIR_CLOCKWISE : SPARKI_MOTOR_DIR_COUNTERCLOCKWISE,
+    0,  // speed percent is don't-care; interrupt interval is set directly below
+    true
+  );
+  motorUpdateIntervalIntEvents[innerWheelIndex] = innerWheelUpdatePeriodIntEv - 1;
+  motorTimeToUpdateIntEvents[innerWheelIndex]   = innerWheelUpdatePeriodIntEv - 1;
+
+  sei ();
+
+  startMotorRotation ( SPARKI_MOTOR_ID_MASK_WHEELS, waitUntilDone );
+
+  // Finish special handling of negative turn radius...
+  
+  if ( negRadSpinAngleDeg != 0 ) spin ( - negRadSpinAngleDeg );
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::turnLeft (
+  int16_t angleToTurnDeg,
+  int16_t radiusOfTurnMm,
+  boolean waitUntilDone,
+  int8_t  speedPercent
+) {
+
+  turn ( angleToTurnDeg, false, radiusOfTurnMm, waitUntilDone, speedPercent );
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::turnRight (
+  int16_t angleToTurnDeg,
+  int16_t radiusOfTurnMm,
+  boolean waitUntilDone,
+  int8_t  speedPercent
+) {
+
+  turn ( angleToTurnDeg, true, radiusOfTurnMm, waitUntilDone, speedPercent );
+
+}
+
+// ----------------------------------------------------------------------------
+
+boolean SparkiClass::wheelsAreRunning () {
+
+  return anyMotorIsRunning ( SPARKI_MOTOR_ID_MASK_WHEELS );
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::stopWheels () {
+
+  stopMotorRotation ( SPARKI_MOTOR_ID_MASK_WHEELS );
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+boolean SparkiClass::wheelsAreDone () {
+
+  byte    motorIdMask;
+  uint8_t motorIndex;
+  boolean wheelsDone;
+
+  motorIdMask = SPARKI_MOTOR_ID_MASK_WHEELS;
+
+  wheelsDone = true;
+
+  motorIndex = 0;
+  while ( motorIdMask != 0x00 ) {
+    if ( motorIdMask & 0x01 ) {
+      wheelsDone = wheelsDone && 
+        ( motorStatusWord[motorIndex] & SPARKI_MOTOR_STATUS_MASK_MTR_IS_RUNNING ) &&
+        motorRemainingSteps[motorIndex] == 0;
+    }
+    motorIdMask >>= 1;
+    motorIndex++;
+  }
+
+  return wheelsDone;
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::restartWheels (
+  boolean waitUntilDone
+) {
+
+  startMotorRotation ( SPARKI_MOTOR_ID_MASK_WHEELS, waitUntilDone );
+
+}
+
+// ----------------------------------------------------------------------------
+
+void SparkiClass::openGripper (
+  int8_t  amountToOpenMm,
+  boolean waitUntilDone,
+  int8_t  speedPercent
+) {
+
+  uint8_t  absAmountToOpenMm;
+  uint32_t stepsToMove;
+
+  if ( gripperIsRunning() ) stopGripper ();
+
+  if ( speedPercent < 0 ) speedPercent = gripperSpeedPercentDefault;
+
+  if ( amountToOpenMm != 0 ) {
+
+    if ( amountToOpenMm >= 0 ) {
+      absAmountToOpenMm = amountToOpenMm;
+      if ( absAmountToOpenMm >= SPARKI_MOTOR_GRIPPER_OPEN_MAX_MM ) {
+        amountToOpenMm    =   SPARKI_MOTOR_GRIPPER_OPEN_MAX_MM;
+        absAmountToOpenMm =   SPARKI_MOTOR_GRIPPER_OPEN_MAX_MM;
+        gripperSpacingMm  =   0;
+      }
+    }
+    else {
+      absAmountToOpenMm = - amountToOpenMm;
+      if ( absAmountToOpenMm >= SPARKI_MOTOR_GRIPPER_OPEN_MAX_MM ) {
+        amountToOpenMm    = - SPARKI_MOTOR_GRIPPER_OPEN_MAX_MM;
+        absAmountToOpenMm =   SPARKI_MOTOR_GRIPPER_OPEN_MAX_MM;
+        gripperSpacingMm  =   SPARKI_MOTOR_GRIPPER_OPEN_MAX_MM;
+      }
+    }
+
+    if ( gripperSpacingMm >= 0 ) {
+      gripperSpacingMm += amountToOpenMm;
+      if ( gripperSpacingMm < 0 ) {
+        gripperSpacingMm = 0;
+      }
+      if ( gripperSpacingMm > SPARKI_MOTOR_GRIPPER_OPEN_MAX_MM ) {
+        gripperSpacingMm = SPARKI_MOTOR_GRIPPER_OPEN_MAX_MM;
+      }
+    }
+
+    stepsToMove = (
+        (uint32_t) absAmountToOpenMm *
+        SPARKI_MOTOR_GRIP_MM_TO_STEPS_FP
+      ) >> SPARKI_MOTOR_GRIP_MM_TO_STEPS_FP_FRACT_BITS;
+    // steps = mm * teeth/mm * rev/teeth * steps/rev / 2
+    //       = mm / mm/teeth / teeth/rev * steps/rev / 2
+    //       = ( mm * steps/rev ) / ( mm/teeth * teeth/rev * 2 )
+    //       = mm * SPARKI_MOTOR_GRIP_MM_TO_STEPS
+
+    cli ();
+
+    setupMotorForSteps (
+      SPARKI_MOTOR_ID_MASK_GRIPPER,
+      stepsToMove,
+      amountToOpenMm > 0 ? SPARKI_MOTOR_DIR_COUNTERCLOCKWISE : SPARKI_MOTOR_DIR_CLOCKWISE,
+      speedPercent,
+      true
+    );
+
+    sei ();
+
+    startMotorRotation ( SPARKI_MOTOR_ID_MASK_GRIPPER, waitUntilDone );
+
+  }
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::closeGripper (
+  int8_t  amountToCloseMm,
+  boolean waitUntilDone,
+  int8_t  speedPercent
+) {
+
+  openGripper ( -amountToCloseMm, waitUntilDone, speedPercent );
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::setGripperSpacing (
+  uint8_t spacingMm,
+  boolean waitUntilDone,
+  int8_t  speedPercent
+) {
+
+  int8_t amountToOpenMm;
+
+  if ( gripperSpacingMm >= 0 ) {
+    amountToOpenMm = (int8_t) spacingMm - gripperSpacingMm;
+    openGripper ( amountToOpenMm, waitUntilDone, speedPercent );
+  }
+
+}
+
+// ----------------------------------------------------------------------------
+
+boolean SparkiClass::gripperIsRunning () {
+
+  return anyMotorIsRunning ( SPARKI_MOTOR_ID_MASK_GRIPPER );
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::stopGripper () {
+
+  uint8_t  distanceNotTraveledMm;
+
+  if ( gripperIsRunning() ) {
+
+    stopMotorRotation ( SPARKI_MOTOR_ID_MASK_GRIPPER );
+
+    if ( gripperSpacingMm >= 0 ) {
+
+      distanceNotTraveledMm = ( 
+          motorRemainingSteps[SPARKI_MOTOR_INDEX_GRIPPER] *
+          SPARKI_MOTOR_GRIP_STEPS_TO_MM_FP
+        ) >> SPARKI_MOTOR_GRIP_STEPS_TO_MM_FP_FRACT_BITS;
+      // mm = steps * rev/steps * teeth/rev * mm/teeth * 2
+      //    = steps / steps/rev * teeth/rev * mm/teeth * 2
+      //    = ( steps * teeth/rev * mm/teeth * 2 ) / steps/rev
+      //    = steps * SPARKI_MOTOR_GRIP_STEPS_TO_MM
+
+      if ( motorStatusWord[SPARKI_MOTOR_INDEX_GRIPPER] & SPARKI_MOTOR_STATUS_MASK_DIR_IS_CW ) {
+        gripperSpacingMm += distanceNotTraveledMm;
+      }
+      else {
+        gripperSpacingMm -= distanceNotTraveledMm;
+      }
+
+    }  // if ( gripperSpacingMm >= 0 )
+
+  }  // if ( gripperIsRunning() )
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+boolean SparkiClass::gripperIsDone () {
+
+  return motorRemainingSteps[SPARKI_MOTOR_INDEX_GRIPPER] == 0;
+
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+void SparkiClass::restartGripper (
+  boolean waitUntilDone
+) {
+
+  startMotorRotation ( SPARKI_MOTOR_ID_MASK_GRIPPER, waitUntilDone );
+
+}
+
+// ----------------------------------------------------------------------------
+// Motor Control: Legacy Functions / Backward Compatibility
+// ----------------------------------------------------------------------------
+
+void SparkiClass::moveLeft ( float deg ) {
+  boolean savedZeroMeansInfinity;
+  savedZeroMeansInfinity = distanceOfZeroMeansInfinity;
+  distanceOfZeroMeansInfinity = true;
+  spinLeft ( (int16_t) deg );
+  distanceOfZeroMeansInfinity = savedZeroMeansInfinity;
+}
+void SparkiClass::moveLeft () {
+  spinLeft ();
+}
+
+void SparkiClass::moveRight ( float deg ) {
+  boolean savedZeroMeansInfinity;
+  savedZeroMeansInfinity = distanceOfZeroMeansInfinity;
+  distanceOfZeroMeansInfinity = true;
+  spinRight ( (int16_t) deg );
+  distanceOfZeroMeansInfinity = savedZeroMeansInfinity;
+}
+void SparkiClass::moveRight () {
+  spinRight ();
+}
+
+void SparkiClass::moveForward ( float cm ) {
+  boolean savedZeroMeansInfinity;
+  savedZeroMeansInfinity = distanceOfZeroMeansInfinity;
+  distanceOfZeroMeansInfinity = true;
+  driveForward ( (int16_t) ( cm * 10 ) );
+  distanceOfZeroMeansInfinity = savedZeroMeansInfinity;
+}
+void SparkiClass::moveForward () {
+  driveForward ();
+}
+
+void SparkiClass::moveBackward ( float cm ) {
+  boolean savedZeroMeansInfinity;
+  savedZeroMeansInfinity = distanceOfZeroMeansInfinity;
+  distanceOfZeroMeansInfinity = true;
+  driveBackward ( (int16_t) ( cm * 10 ) );
+  distanceOfZeroMeansInfinity = savedZeroMeansInfinity;
+}
+void SparkiClass::moveBackward () {
+  driveBackward ();
+}
+
+void SparkiClass::moveStop () {
+  stopWheels ();
+}
+
+void SparkiClass::gripperOpen () {
+  openGripper ();
+}
+void SparkiClass::gripperClose () {
+  closeGripper ();
+}
+
+void SparkiClass::gripperStop () {
+  stopGripper ();
+}
+
+void SparkiClass::motorRotate ( int motor, int direction, int speed ) {
+  rotateMotorsBySteps ( 0x01 < motor, ULONG_MAX, direction == DIR_CW, speed, false );
+  delay ( 10 );
+}
+
+void SparkiClass::motorStop ( int motor ) {
+  stopMotorRotation ( 0x01 < motor );
+}
+
+void SparkiClass::motorsRotateSteps ( int leftDir, int rightDir, int speed, uint32_t steps, bool wait ) {
+  cli ();
+  setupMotorForSteps ( SPARKI_MOTOR_ID_MASK_WHEEL_LEFT,  steps, leftDir  == DIR_CW, speed, true );
+  setupMotorForSteps ( SPARKI_MOTOR_ID_MASK_WHEEL_RIGHT, steps, rightDir == DIR_CW, speed, true );
+  sei ();
+  startMotorRotation ( SPARKI_MOTOR_ID_MASK_WHEELS, wait ); 
 }
  
- // returns true if one or both motors a still stepping
- bool SparkiClass::areMotorsRunning()
- {
-   bool result;
-   uint8_t oldSREG = SREG;
-   cli();
-   result =  isRunning[MOTOR_LEFT] || isRunning[MOTOR_RIGHT] || isRunning[MOTOR_GRIPPER] ;
-   SREG = oldSREG; 
-   sei();
-   return result;
- }
+bool SparkiClass::areMotorsRunning ( ) {
+  return anyMotorIsRunning ( SPARKI_MOTOR_ID_MASK_ALL );
+}
+
+// ----------------------------------------------------------------------------
+// ----------------------------------------------------------------------------
 
 int SparkiClass::ping_single(){
   long duration; 
@@ -763,46 +1991,37 @@ uint8_t* SparkiClass::WireRead(int address, int length){
   Wire.endTransmission();
 }
 
- /*
-  * private functions
-  */
- 
- // set the number if steps for the given motor 
-
-
-void SparkiClass::setSteps(uint8_t motor, uint32_t steps)
-{
-   uint8_t oldSREG = SREG;
-   cli();
-   remainingSteps[motor] = steps; // motor stops after this many steps
-   isRunning[motor] = steps > 0;
-   SREG = oldSREG;    
-   sei();
-}
-
-uint32_t SparkiClass::getSteps(uint8_t motor )
-{
-   uint8_t oldSREG = SREG;
-   cli();
-   uint32_t steps = remainingSteps[motor];
-   SREG = oldSREG;    
-   sei();
-   return steps;
-}
-
 /***********************************************************************************
 The Scheduler
-Every 100uS (10,000 times a second), we update the 2 shift registers used to increase
+Every 200uS (5,000 times a second), we update the 2 shift registers used to increase
 the amount of outputs the processor has
 ***********************************************************************************/
 
-ISR(TIMER4_COMPA_vect)          // interrupt service routine that wraps a user defined function supplied by attachInterrupt
-{
-//void SparkiClass::scheduler(){ 
-    uint8_t oldSREG = SREG;
-    // Clear the timer interrupt counter 
-    TCNT4=0;
-    
+// ISR: interrupt service routine for timer interrupt. This interrupt
+// service routine then calls a Sparki library function that performs
+// whatever tasks are necessary. By calling the library function instead
+// of just placing the library function's code directly into the ISR, the
+// code can reference private members of the the Sparki class instance,
+// so that low-level, private state does not need to reside and be exposed
+// at global scope.
+
+ISR ( TIMER4_COMPA_vect ) { 
+  byte oldSREG = SREG;
+  TCNT4 = 0;  // clearing the timer interrupt counter 
+  sparki.updateShiftReg ();
+  SREG = oldSREG;
+}
+
+// updateShiftReg: function to update shift register that extends number of
+// processor outputs. This function is called automatically through timer
+// interrupts. Under normal circumstances, it should not be called by user
+// or library code. If it does need to be called; it should be bracketed by
+// cli() / sei().
+
+void SparkiClass::updateShiftReg () { 
+
+    byte shift_outputs[2];
+
 	// clear the shift register values so we can re-write them
     shift_outputs[0] = 0x00;
     shift_outputs[1] = 0x00;
@@ -829,53 +2048,108 @@ ISR(TIMER4_COMPA_vect)          // interrupt service routine that wraps a user d
     else{
     	shift_outputs[1] |= 0x08;
     }
-    
-    //// Motor Control ////
-    
-    //   Determine what state the stepper coils are in
-	for(byte motor=0; motor<3; motor++){
-		if( remainingSteps[motor] > 1 ){ // check if finished stepping     
-			if( speedCounter[motor] == 0) { // 
-				step_index[motor] += step_dir[motor];
-				remainingSteps[motor]--;
-				speedCounter[motor] = speedCount[motor];
-			}
-			else{
-				speedCounter[motor] = speedCounter[motor]-1;
-			}
-			
-		}
-		else {  // if this was the last step
-			remainingSteps[motor] = 0;  
-			isRunning[motor] = false;
-			step_index[motor] = 8;
-			speedCounter[motor] = -1;
-		}     
-		
-		//   keep indicies from rolling over or under
-		if( step_index[motor] >= 8){
-			step_index[motor] = 0;
-		}
-		else if( step_index[motor] < 0){
-			step_index[motor] = 7;
-		}
-		if(isRunning[motor] == false){
-			step_index[motor] = 8;
-		}
-	}
 
-    shift_outputs[0] |= _steps_right[step_index[MOTOR_RIGHT]];
-    shift_outputs[0] |= _steps_left[step_index[MOTOR_GRIPPER]];
+  // BEGIN: Motor Control
+
+  byte    motorIdMask;
+  uint8_t motorIndex;
+  boolean motorIsOnActiveHold;
+  boolean motorIsRunning;
+
+  boolean advanceStepperCoilsNow;
+  boolean driveStepperCoilsNow;
+  byte    stepperControlLast;
+  byte    stepperControlRotated;
+  byte    stepperControlNow;
     
-    shift_outputs[1] |= _steps_left[step_index[MOTOR_LEFT]];
-    
+  motorIndex = 0;
+  motorIdMask = SPARKI_MOTOR_ID_MASK_ALL;
+
+  while ( motorIdMask != 0x00 ) {
+
+    if ( motorIdMask & 0x01 ) {
+
+      motorIsOnActiveHold = motorStatusWord[motorIndex] & SPARKI_MOTOR_STATUS_MASK_ACT_HOLD_IS_ON;
+      motorIsRunning = motorStatusWord[motorIndex] & SPARKI_MOTOR_STATUS_MASK_MTR_IS_RUNNING;
+
+      driveStepperCoilsNow = motorIsOnActiveHold || motorIsRunning;
+
+      if ( driveStepperCoilsNow ) {
+
+        stepperControlLast = motorControlWord[motorIndex];
+
+        advanceStepperCoilsNow = motorIsRunning && motorTimeToUpdateIntEvents[motorIndex] == 0;
+ 
+        if ( advanceStepperCoilsNow ) {
+
+          if ( motorStatusWord[motorIndex] & SPARKI_MOTOR_STATUS_MASK_DIR_IS_CW ) {
+            stepperControlRotated = ( stepperControlLast << 1 ) | ( stepperControlLast >> 7 );
+          }
+          else {
+            stepperControlRotated = ( stepperControlLast >> 1 ) | ( stepperControlLast << 7 );
+          }
+
+          stepperControlNow = stepperControlRotated & stepperControlLast;
+          if ( stepperControlNow == 0x00 ) {
+            stepperControlNow = stepperControlRotated | stepperControlLast;
+          }
+
+          motorControlWord[motorIndex] = stepperControlNow;
+
+          motorRemainingSteps[motorIndex]--;
+
+          if ( motorRemainingSteps[motorIndex] > 0 ) {
+            motorTimeToUpdateIntEvents[motorIndex] = motorUpdateIntervalIntEvents[motorIndex];
+          }
+          else {
+            motorStatusWord[motorIndex] &= ~ SPARKI_MOTOR_STATUS_MASK_MTR_IS_RUNNING;
+          }
+
+        }  // if (  advanceStepperCoilsNow )
+        else {
+
+          stepperControlNow = stepperControlLast;
+          if ( motorIsRunning ) motorTimeToUpdateIntEvents[motorIndex]--;
+
+        }  // if (  advanceStepperCoilsNow ) ... else
+
+      }  // if ( driveStepperCoilsNow )
+      else {
+
+        stepperControlNow = 0x00;
+
+      }  // if ( driveStepperCoilsNow ) ... else
+
+      switch ( motorIndex ) {
+        case SPARKI_MOTOR_INDEX_WHEEL_LEFT:
+          shift_outputs[SPARKI_SHIFT_REG_INDEX_MOTOR_WHEEL_LEFT] |= 
+            ( stepperControlNow & SPARKI_SHIFT_REG_MASK_MOTOR_WHEEL_LEFT );
+          break;
+        case SPARKI_MOTOR_INDEX_WHEEL_RIGHT:
+          shift_outputs[SPARKI_SHIFT_REG_INDEX_MOTOR_WHEEL_RIGHT] |= 
+            stepperControlNow & SPARKI_SHIFT_REG_MASK_MOTOR_WHEEL_RIGHT;
+          break;
+        case SPARKI_MOTOR_INDEX_GRIPPER:
+          shift_outputs[SPARKI_SHIFT_REG_INDEX_MOTOR_GRIPPER] |=
+            stepperControlNow & SPARKI_SHIFT_REG_MASK_MOTOR_GRIPPER;
+          break;
+      }  // switch ( motorIndex )
+
+    }  // if ( motorIdMask & 0x01 )
+
+    motorIdMask >>= 1;
+    motorIndex++;
+
+  }  // while ( motorIdMask & 0x01 )
+
+  // END: Motor Control
     
 	//output values to shift registers
     PORTD &= ~(1<<5);    // pull PD5 (shift-register latch) low
     SPI.transfer(shift_outputs[1]);
     SPI.transfer(shift_outputs[0]);
     PORTD |= (1<<5);    // pull PD5 (shift-register latch) high 
-    SREG = oldSREG;
+
 }
 
 /***********************************************************************************
@@ -1832,3 +3106,4 @@ void SparkiClass::readi2cRegister(unsigned char address, unsigned char data, uin
 
   i2cSendStop();
 }
+

--- a/Arduino Library/Sparki.h
+++ b/Arduino Library/Sparki.h
@@ -84,33 +84,207 @@
 #define RGB_WHITE   60,  100, 90
 #define RGB_OFF     0,   0,   0
 
-// properties about the robot in cm
-#define PI 3.14159
-const float WHEEL_DIAMETER_CM     = 5.15;
-const float WHEEL_CIRCUMFERENCE_CM = WHEEL_DIAMETER_CM * PI;
-const float TRACK_WIDTH            = 11.1;              //tyre seperation in cm  
-//const float WHEEL_TRAVEL_PER_360   = WHEEL_TRACK * PI;  // cm per ROBOT revolution 
+// ----------------------------------------------------------------------------
 
-const int   STEPS_PER_REV      = 8192; // steps for wheels to revolve 360 degrees
+#define SPARKI_DEBUG_L1_ACTION  0x01
+#define SPARKI_DEBUG_L1_STATUS  0x02
+#define SPARKI_DEBUG_L2_ACTION  0x04
+#define SPARKI_DEBUG_L2_STATUS  0x08
+#define SPARKI_DEBUG_L3_ACTION  0x10
+#define SPARKI_DEBUG_L3_STATUS  0x20
+#define SPARKI_DEBUG_MIDDLE     0x40
+#define SPARKI_DEBUG_END        0x80
 
+#define SPARKI_DEBUG_MODE       0x00
 
-const float STEPS_PER_CM       = STEPS_PER_REV / WHEEL_CIRCUMFERENCE_CM; // linear movement
-const float STEPS_PER_ROTATION = (TRACK_WIDTH / WHEEL_DIAMETER_CM) * STEPS_PER_REV ;  // robot rotation
-const float STEPS_PER_DEGREE   = STEPS_PER_ROTATION / 360.0;         // robot rotation
-const float CM_PER_DEGREE      = WHEEL_CIRCUMFERENCE_CM / 360.0;     // wheel movement per degree rotation of robot 
+// ----------------------------------------------------------------------------
 
-// circumference = 16.18
+#define SPARKI_INTERRUPT_PERIOD_US  200
 
+// ----------------------------------------------------------------------------
+
+#define SPARKI_MOTOR_STEPS_PER_REV      4096
+#define SPARKI_MOTOR_STEPS_OF_BACKLASH    48
+#define SPARKI_MOTOR_PRIMING_STEPS         8
+
+#define SPARKI_MOTOR_UPDATE_PERIOD_MIN_US   1000
+#define SPARKI_MOTOR_UPDATE_PERIOD_MAX_US  10000
+// NOTE: Assumptions/Requirements:
+//   SPARKI_MOTOR_UPDATE_PERIOD_MIN_US >= SPARKI_INTERRUPT_PEIOD_US
+//   SPARKI_MOTOR_UPDATE_PERIOD_MAX_US > SPARKI_MOTOR_UPDATE_PERIOD_MIN_US
+// NOTE: From 28BYJ-48 5V stepper motor data sheet:
+//   Frequency                    100Hz
+//   Idle In-traction Frequency   > 600Hz
+//   Idle Out-traction Frequency  > 1000Hz
+// Not really sure what these mean...?
+// The shortest stepper coil update period that
+// seems to work reliabily is 1000us. If the 1000
+// ends up being flaky on some Sparki units, the
+// setting will need to be changed to 1200. (Or,
+// if the interrupt period is reduced to 100us,
+// perhaps a motor update period of 900us would
+// work to make the motors a little faster?)
+
+#define SPARKI_MOTOR_SPEED_DEFAULT_PERCENT   80
+// NOTE: Speed to update period mapping:
+//   100% --> effective motor update period == SPARKI_MOTOR_UPDATE_PERIOD_MIN_US
+//     0% --> effective motor update period == SPARKI_MOTOR_UPDATE_PERIOD_MAX_US
+
+#define SPARKI_MOTOR_COUNT  3
+
+#define SPARKI_MOTOR_INDEX_WHEEL_LEFT   0
+#define SPARKI_MOTOR_INDEX_WHEEL_RIGHT  1
+#define SPARKI_MOTOR_INDEX_GRIPPER      2
+
+#define SPARKI_MOTOR_ID_MASK_WHEEL_LEFT   0x01  // 0x01 << SPARKI_MOTOR_INDEX_WHEEL_LEFT
+#define SPARKI_MOTOR_ID_MASK_WHEEL_RIGHT  0x02  // 0x01 << SPARKI_MOTOR_INDEX_WHEEL_RIGHT
+#define SPARKI_MOTOR_ID_MASK_GRIPPER      0x04  // 0x01 << SPARKI_MOTOR_INDEX_GRIPPER
+
+#define SPARKI_MOTOR_ID_MASK_WHEELS       0x03  // SPARKI_MOTOR_ID_MASK_WHEEL_LEFT | SPARKI_MOTOR_ID_MASK_WHEEL_RIGHT
+#define SPARKI_MOTOR_ID_MASK_ALL          0x07  // SPARKI_MOTOR_ID_MASK_WHEELS | SPARKI_MOTOR_ID_MASK_GRIPPER
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+#define SPARKI_MOTOR_STATUS_MASK_DIR_IS_CW       0x01
+#define SPARKI_MOTOR_STATUS_MASK_ACT_HOLD_IS_ON  0x02
+#define SPARKI_MOTOR_STATUS_MASK_BLCOMP_IS_ON    0x04
+#define SPARKI_MOTOR_STATUS_MASK_BLCOMP_IS_PEND  0x08
+#define SPARKI_MOTOR_STATUS_MASK_MTR_IS_RUNNING  0x80
+
+#define SPARKI_SHIFT_REG_INDEX_MOTOR_WHEEL_LEFT   1
+#define SPARKI_SHIFT_REG_INDEX_MOTOR_WHEEL_RIGHT  0
+#define SPARKI_SHIFT_REG_INDEX_MOTOR_GRIPPER      0
+
+#define SPARKI_SHIFT_REG_MASK_MOTOR_WHEEL_LEFT   0xf0
+#define SPARKI_SHIFT_REG_MASK_MOTOR_WHEEL_RIGHT  0x0f
+#define SPARKI_SHIFT_REG_MASK_MOTOR_GRIPPER      0xf0
+
+#define SPARKI_MOTOR_DIR_CLOCKWISE         true
+#define SPARKI_MOTOR_DIR_COUNTERCLOCKWISE  false
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+#define SPARKI_WHEEL_DIAMETER_BASELINE_UM    510  // baseline wheel diameter is 51.0mm --> 510um
+#define SPARKI_WHEEL_TRACK_WIDTH_UM          855  // baseline wheel separation is 85.5mm --> 855um
+#define SPARKI_WHEEL_SEPARATION_BASELINE_UM  SPARKI_WHEEL_TRACK_WIDTH_UM
+
+#define SPARKI_MOTOR_WHEEL_FP_FRACTION_BITS        6       // number of fractional bits for wheel-specific fixed point (fp) numbers
+#define SPARKI_MOTOR_WHEEL_CIRCUMFERENCE_MM_FP     0x280E  // 161.792022mm as fixed point, assuming wheel diameter = 51.0mm
+#define SPARKI_MOTOR_WHEEL_SPIN_CIRCLE_CIRC_MM_FP  0x4327  // 267.035376mm as fixed point, assuming wheel separation = 85.5mm
+
+#define SPARKI_MOTOR_GRIPPER_OPEN_MAX_MM   70
+#define SPARKI_MOTOR_GRIPPER_PINION_TEETH  11
+
+#define SPARKI_GRIPPER_FP_FRACTION_BITS  10      // number of fractional bits for gripper-specific fixed point numbers
+#define SPARKI_GRIPPER_TOOTH_STEP_MM_FP  0x0B9A  // 2.9mm as fixed point
+
+// wheel -- fixed-point fraction bits: 6
+// -------------------------------------
+// diameter           circumference   
+// 50.5  CA0  0.00%   158.650429  27AA  0.00%
+// 51.0  CC0  0.00%   160.221225  280E  0.00% *
+// 51.5  CE0  0.00%   161.792022  2873  0.00%
+// 52.0  D00  0.00%   163.362818  28D7  0.00%
+//  |     |     |
+//  |     |     +--- percent difference between decimal and fixed point
+//  |     +--- value as fixed point binary
+//  +--- decimal value
+//
+// * == baseline value
+
+// wheel -- fixed-point fraction bits: 8
+// -------------------------------------
+// diameter            circumference             drive mm to steps
+// 50.5  3280  0.00%   158.650429  9EA7  0.00%   25.817768  19D1  -0.01%
+// 51.0  3300  0.00%   160.221225  A039  0.00%   25.564653  1991   0.01% *
+// 51.5  3380  0.00%   161.792022  A1CB  0.00%   25.316452  1951   0.00%
+// 52.0  3400  0.00%   163.362818  A35D  0.00%   25.073025  1913   0.00%
+
+// spin circle -- fixed-point fraction bits: 6
+// -------------------------------------------
+// diameter            circumference
+// 84.0  1500  0.00%   263.893783  41F9  0.00%
+// 84.5  1520  0.00%   265.464579  425E  0.00%
+// 85.0  1540  0.00%   267.035376  42C2  0.00%
+// 85.5  1560  0.00%   268.606172  4327  0.00% *
+// 86.0  1580  0.00%   270.176968  438B  0.00%
+// 86.5  15A0  0.00%   271.747765  43F0  0.00%
+// 87.0  15C0  0.00%   273.318561  4454  0.00%
+// (spin circle diameter == wheel separation)
+
+// spin deg to steps -- fixed-point fraction bits: 8
+// -------------------------------------------------
+//            50.5       51.0       51.5       52.0         50.5  51.0  51.5  52.0           50.5    51.0    51.5    52.0
+// 84.0  18.925413  18.739869  18.557929  18.379487   84.0  12ED  12BD  128F  1261   84.0   0.00%  -0.01%   0.00%   0.00%
+// 84.5  19.038064  18.851416  18.668393  18.488889   84.5  130A  12DA  12AB  127D   84.5   0.01%   0.00%   0.00%   0.00%
+// 85.0  19.150715  18.962963  18.778857  18.598291   85.0  1327  12F7  12C7  1299   85.0   0.01%   0.01%  -0.01%   0.00%
+// 85.5  19.263366  19.074510  18.889320  18.707692   85.5  1343  1313  12E4  12B5   85.5  -0.01%   0.00%   0.01%   0.00% *
+// 86.0  19.376018  19.186057  18.999784  18.817094   86.0  1360  1330  1300  12D1   86.0  -0.01%   0.01%   0.00%   0.00%
+// 86.5  19.488669  19.297603  19.110248  18.926496   86.5  137D  134C  131C  12ED   86.5   0.00%   0.00%   0.00%   0.00%
+// 87.0  19.601320  19.409150  19.220712  19.035897   87.0  139A  1369  1339  1309   87.0   0.00%   0.01%   0.01%   0.00%
+//                                                                  *
+
+// turn angle and radius to steps -- fixed-point bits: 12
+// ------------------------------------------------------
+// 50.0  0.455111  748  -0.01%
+// 50.5  0.450605  736   0.02%
+// 51.0  0.446187  724   0.02% *
+// 51.5  0.441855  712   0.01%
+// 52.0  0.437607  700  -0.02%
+
+// gripper -- fixed-point fraction bits: 10
+// ----------------------------------------
+// tooth separation
+// 2.70  ACD   0.01%
+// 2.80  B33  -0.01%
+// 2.90  B9A   0.01% *
+// 3.00  C00   0.00%
+// 3.10  C66  -0.01%
+// 3.20  CCD   0.01%
+
+// gripper -- fixed-point fraction bits: 16
+// ----------------------------------------
+// tooth separation     grip mm to steps           steps to grip mm
+// 2.70  2B333  0.00%   68.956229  44F4CB  0.00%   0.014502  3B6  -0.04%
+// 2.80  2CCCD  0.00%   66.493506  427E56  0.00%   0.015039  3DA   0.04%
+// 2.90  2E666  0.00%   64.200627  40335C  0.00%   0.015576  3FD   0.02% *
+// 3.00  30000  0.00%   62.060606  3E0F84  0.00%   0.016113  420   0.00%
+// 3.10  3199A  0.00%   60.058651  3C0F04  0.00%   0.016650  443  -0.02%
+// 3.20  33333  0.00%   58.181818  3A2E8C  0.00%   0.017188  466  -0.04%
+
+#define SPARKI_MOTOR_DRIVE_MM_TO_STEPS_FP             0x1991  // must be consistent with baseline wheel diameter
+#define SPARKI_MOTOR_DRIVE_MM_TO_STEPS_FP_FRACT_BITS  8
+#define SPARKI_MOTOR_DRIVE_MM_MAX_BITS                16
+
+#define SPARKI_MOTOR_SPIN_DEG_TO_STEPS_FP             0x1313  // must be consistent with baseline wheel diameter and separation
+#define SPARKI_MOTOR_SPIN_DEG_TO_STEPS_FP_FRACT_BITS  8
+#define SPARKI_MOTOR_SPIN_DEG_MAX_BITS                16
+
+#define SPARKI_TURN_RADIUSMM_ANGLEDEG_TO_STEPS_FP             0x724  // must be consistent with baseline wheel diameter
+#define SPARKI_TURN_RADIUSMM_ANGLEDEG_TO_STEPS_FP_FRACT_BITS  12
+#define SPARKI_TURN_RADIUS_DEFAULT_MM                         75
+#define SPARKI_WHEEL_TURN_WITH_NEG_RAD_ALTERNATE              false
+
+#define SPARKI_MOTOR_GRIP_MM_TO_STEPS_FP             0x40335C  // must be consistent with gripper tooth separation
+#define SPARKI_MOTOR_GRIP_MM_TO_STEPS_FP_FRACT_BITS  16
+#define SPARKI_MOTOR_GRIP_MM_MAX_BITS                8
+
+#define SPARKI_MOTOR_GRIP_STEPS_TO_MM_FP             0x03FD
+#define SPARKI_MOTOR_GRIP_STEPS_TO_MM_FP_FRACT_BITS  16
+#define SPARKI_MOTOR_GRIP_STEPS_MAX_BITS             24
+
+// ----------------------------------------------------------------------------
 
 // defines for left and right motors
-#define MOTOR_LEFT  0
-#define MOTOR_RIGHT 1
-#define MOTOR_GRIPPER 2
+#define MOTOR_LEFT    0  // deprecated, to be removed?
+#define MOTOR_RIGHT   1  // deprecated, to be removed?
+#define MOTOR_GRIPPER 2  // deprecated, to be removed?
 
 // defines for direction
-#define DIR_CCW -1
-#define DIR_CW   1
+#define DIR_CCW -1       // deprecated, to be removed?
+#define DIR_CW   1       // deprecated, to be removed?
 
+// ----------------------------------------------------------------------------
 
 //includes for the LCD 
 
@@ -262,37 +436,140 @@ public:
   void servo(int);
   int8_t servo_deg_offset;
 
-// high-level move functions
-  void moveForward(float);
-  void moveForward();
-  
-  void moveBackward(float);
-  void moveBackward();
-  
-  void moveLeft(float);
-  void moveLeft();
-  
-  void moveRight(float);
-  void moveRight();
-  
-  void moveStop();
-   
-  void gripperOpen();
-  void gripperClose();
-  void gripperStop();
+    // BEGIN: Motor Control (wheels and gripper)
 
-// individual motor control (non-blocking)
-// speed range is percent 0-100
-  void motorRotate( int motor, int direction,  int speed);
-  void motorStop(int motor);
+    boolean distanceOfZeroMeansInfinity;
+    uint8_t wheelSpeedPercentDefault;
+    uint8_t gripperSpeedPercentDefault;
 
-// combined motor control using step count
-// this function blocks by default but returns after starting motors if wait = false
-  void motorsRotateSteps( int leftDir, int rightDir,  int speed, uint32_t steps, bool wait= true);
- 
-// returns true if one or both motors a still stepping
-  bool areMotorsRunning();
+    void setWheelDiameter (
+      uint16_t wheelDiameterUm
+    );
+    void setWheelSeparation (
+      uint16_t wheelSeparationUm
+    );
+
+    void primeMotors ();
+
+    void enableActiveHoldForWheels (
+      boolean enableActiveHold
+    );
+    void enableActiveHoldForGripper (
+      boolean enableActiveHold
+    );
+    boolean activeHoldIsEnabledForWheels ();
+    boolean activeHoldIsEnabledForGripper ();
+
+    void enableBacklashCompForWheels (
+      boolean enableBacklashComp
+    );
+      void enableBacklashCompForGripper (
+      boolean enableBacklashComp
+    );
+    boolean backlashCompIsEnabledForWheels ();
+    boolean backlashCompIsEnabledForGripper ();
+
+    void driveForward (
+      int16_t distanceToDriveMm = 0,
+      boolean waitUntilDone = true,
+      int8_t  speedPercent = -1
+    );
+
+    void driveBackward (
+      int16_t distanceToDriveMm = 0,
+      boolean waitUntilDone = true,
+      int8_t  speedPercent = -1
+    );
+
+    void spinLeft (
+      int16_t angleToSpinDeg = 0,
+      boolean waitUntilDone = true,
+      int8_t  speedPercent = -1
+    );
+    void spinRight (
+      int16_t angleToSpinDeg = 0,
+      boolean waitUntilDone = true,
+      int8_t  speedPercent = -1
+    );
+
+    void turnLeft (
+      int16_t angleToTurnDeg = 90,
+      int16_t radiusOfTurnMm = SPARKI_TURN_RADIUS_DEFAULT_MM,
+      boolean waitUntilDone = true,
+      int8_t  speedPercent = -1
+    );
+    void turnRight (
+      int16_t angleToTurnDeg = 90,
+      int16_t radiusOfTurnMm = SPARKI_TURN_RADIUS_DEFAULT_MM,
+      boolean waitUntilDone = true,
+      int8_t  speedPercent = -1
+    );
+
+    boolean wheelsAreRunning ();
+    void stopWheels ();
+
+    boolean wheelsAreDone ();
+    void restartWheels (
+      boolean waitUntilDone
+    );
+
+    void openGripper (
+      int8_t  amountToOpenMm = SPARKI_MOTOR_GRIPPER_OPEN_MAX_MM,
+      boolean waitUntilDone = true,
+      int8_t  speedPercent = -1
+    );
+
+    void closeGripper (
+      int8_t  amountToCloseMm = SPARKI_MOTOR_GRIPPER_OPEN_MAX_MM,
+      boolean waitUntilDone = true,
+      int8_t  speedPercent = -1
+    );
+
+    void setGripperSpacing (
+      uint8_t spacingMm,
+      boolean waitUntilDone = true,
+      int8_t  speedPercent = -1
+    );
+
+    boolean gripperIsRunning ();
+    void stopGripper ();
+
+    boolean gripperIsDone ();
+    void restartGripper (
+      boolean waitUntilDone
+    );
+
+    // END: Motor Control (wheels and gripper)
+
+    // BEGIN: Motor Control Legacy Interface (deprecated)
+
+    void moveForward(float);
+    void moveForward();
+    void moveBackward(float);
+    void moveBackward();
+    void moveLeft(float);
+    void moveLeft();
+    void moveRight(float);
+    void moveRight();
+    void moveStop();
+    void gripperOpen();
+    void gripperClose();
+    void gripperStop();
+
+    // individual motor control (non-blocking)
+    // speed range is percent 0-100
+    void motorRotate( int motor, int direction,  int speed);
+    void motorStop(int motor);
+
+    // combined motor control using step count
+    // this function blocks by default but returns after starting motors if wait = false
+    void motorsRotateSteps( int leftDir, int rightDir,  int speed, uint32_t steps, bool wait= true);
    
+    // returns true if one or both motors a still stepping
+    bool areMotorsRunning();
+     
+    // END: Motor Control Legacy Interface
+
   void onIR();
   void offIR();
 
@@ -335,12 +612,158 @@ public:
   void drawBitmap(uint8_t x, uint8_t y, 
 		  const uint8_t *bitmap, uint8_t w, uint8_t h);
 
-private:   
-  uint8_t stepIndex[2];   
-  
-  void setSteps(uint8_t motor, uint32_t steps);  // sets the number of remaining steps, motor stops when this is 0
-  uint32_t getSteps(uint8_t motor ); // returns the number of remaining steps
-  static void scheduler();
+  void updateShiftReg ();
+  // updateShiftReg: function to update shift register that extends number of
+  // processor outputs. This function is called automatically through timer
+  // interrupts. Under normal circumstances, it should not be called by user
+  // or library code. If it does need to be called; it should be bracketed by
+  // cli() / sei().
+
+private:
+
+    // BEGIN: Motor Control, Private Assets
+
+    volatile byte     motorControlWord             [SPARKI_MOTOR_COUNT];
+    volatile byte     motorStatusWord              [SPARKI_MOTOR_COUNT];
+             uint32_t motorRemainingSteps          [SPARKI_MOTOR_COUNT];
+             uint16_t motorUpdateIntervalIntEvents [SPARKI_MOTOR_COUNT];
+             uint16_t motorTimeToUpdateIntEvents   [SPARKI_MOTOR_COUNT];
+             uint16_t wheelDiameterUmEff;
+             uint16_t wheelSeparationUmEff;
+             uint16_t driveMmToStepsEffFp;
+             uint16_t spinDegToStepsEffFp;
+             uint16_t turnRadMmAngleDegToStepsEffFp;
+             int8_t   gripperSpacingMm;
+
+    void initMotorControlWord (
+      uint8_t motorIdMask, 
+      byte    initValue
+    );
+    void initMotorStatusWord (
+      uint8_t motorIdMask, 
+      byte    initValue
+    );
+    void initMotorWord (
+      volatile byte *  motorWord,
+               uint8_t motorIdMask, 
+               byte    initValue
+    );
+
+    void modifyMotorControlWordBit (
+      byte    motorIdMask, 
+      byte    bitSelectMask, 
+      boolean bitValue,
+      boolean motorIdIsIndex = false
+    );
+    void modifyMotorStatusWordBit (
+      byte    motorIdMask, 
+      byte    bitSelectMask, 
+      boolean bitValue,
+      boolean motorIdIsIndex = false
+    );
+    void modifyMotorWordBit (
+      volatile byte *  motorWord,
+               byte    motorIdMask, 
+               byte    bitSelectMask, 
+               boolean bitValue,
+               boolean motorIdIsIndex = false
+    );
+
+    void updateDriveMmToStepsFactor ();
+    void updateSpinDegToStepsFactor ();
+    void updateTurnRadMmAngleDegToStepsFactor ();
+
+    uint8_t motorSpeedPercentToIntEvents (
+      uint8_t  speedPercent
+    );
+    uint8_t motorIntEventsToSpeedPercent (
+      uint16_t updateIntervalIntEvents
+    );
+
+    uint32_t driveDistanceToMotorSteps (
+      uint16_t distanceToDriveMm
+    );
+
+    uint32_t spinAngleToMotorSteps (
+      uint16_t angleToSpinDeg
+    );
+
+    void enableActiveMotorHold (
+      byte    motorIdMask, 
+      boolean enableActiveHold
+    );
+    boolean activeMotorHoldIsEnabledForAny (
+      byte motorIdMask
+    );
+
+    void enableMotorBacklashComp (
+      byte    motorIdMask, 
+      boolean enableBacklashComp
+    );
+    boolean motorBacklashCompIsEnabledForAny (
+      byte motorIdMask
+    );
+    void performMotorBacklashCompensation (
+      byte motorIdMask
+    );
+
+    void setupMotorForSteps (
+      byte     motorIdMask,
+      uint32_t stepCount,
+      boolean  stepClockwise,
+      uint8_t  speedPercent = -1,
+      boolean  stopIfRunning = true
+    );
+
+    void startMotorRotation (
+      byte    motorIdMask,
+      boolean waitUntilDone = true
+    );
+    void stopMotorRotation (
+      byte motorIdMask
+    );
+
+    void rotateMotorsBySteps (
+      byte     motorIdMask,
+      uint32_t stepCount,
+      int8_t   turnDirection,
+      boolean  waitUntilDone = true,
+      uint8_t  speedPercent = -1
+    );
+
+    void drive (
+      int16_t distanceToDriveMm,
+      boolean directionIsFoward = true,
+      boolean waitUntilDone = true,
+      int8_t  speedPercent = -1
+    );
+
+    void spin (
+      int16_t angleToSpinDeg,
+      boolean directionIsRight = true,
+      boolean waitUntilDone = true,
+      int8_t  speedPercent = -1
+    );
+
+    void turn (
+      int16_t angleToTurnDeg,
+      boolean directionIsRight= true,
+      int16_t radiusOfTurnMm = SPARKI_TURN_RADIUS_DEFAULT_MM,
+      boolean waitUntilDone = true,
+      int8_t  speedPercent = -1
+    );
+
+    uint8_t countOfMotorsRunning (
+      byte motorIdMask
+    );
+    boolean anyMotorIsRunning (
+      byte motorIdMask
+    );
+    boolean allMotorsAreRunning (
+      byte motorIdMask
+    );
+
+    // END: Motor Control, Private Assets
 
 // Display Functions
   int8_t sid, sclk, a0, rst, cs;


### PR DESCRIPTION
Fixed constants in move_() functions, so driving by a specific amount of
centimeters and turning by a specific number of degrees works correctly.
Fixed broken code for calling move_() functions with negative arguments.

See also my related post on the Sparki forum:
http://forum.arcbotics.com/viewtopic.php?f=17&t=1069
